### PR TITLE
Update bcrypt to 0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "license": "ISC",
   "dependencies": {
     "argparse": "1.0.2",
-    "bcrypt": "0.8.3"
+    "bcrypt": "^0.8.5"
   }
 }


### PR DESCRIPTION
Adds Node 4/5 support.
